### PR TITLE
Cleans up catalog handling of pending modules

### DIFF
--- a/src/components/catalog-filter/CatalogFilter.tsx
+++ b/src/components/catalog-filter/CatalogFilter.tsx
@@ -25,8 +25,6 @@ interface CatalogFilterDispatch {
   filterBySearchText: (props: CatalogFilterProps, value: string) => void
 }
 
-const defaultStatus = 'released';
-
 export interface CatalogFilterProps extends CatalogFilterValues, CatalogFilterDispatch {
 }
 
@@ -108,7 +106,7 @@ class CatalogFilterInternal extends React.Component<CatalogFilterProps, any> {
         </div>
         <div className="FormElement">
           <Select
-            defaultValue={this.props.catalogFilters?.status || defaultStatus}
+            defaultValue={this.props.catalogFilters?.status}
             helperText="Filter by status"
             id="status"
             labelText="Status"
@@ -135,7 +133,6 @@ class CatalogFilterInternal extends React.Component<CatalogFilterProps, any> {
 
   componentDidMount() {
     this.props.fetchCatalogList()
-    this.props.filterByStatus(this.props, defaultStatus)
   }
 }
 

--- a/src/components/module-group/ModuleGroupTable.tsx
+++ b/src/components/module-group/ModuleGroupTable.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {DataTable, HeaderData} from '../../ui-patterns/data-table/DataTable';
 import {
+  moduleBuildBadgeUrl,
   moduleDisplayName,
   ModuleGroupModel, moduleLatestVersion,
   ModuleModel,
@@ -82,8 +83,10 @@ export class ModuleGroupTable extends React.Component<ModuleTableProps, any> {
   }
 
   moduleBuildBadge(module: ModuleModel) {
+    const imgUrl = moduleBuildBadgeUrl(module)
+
     return (
-      <img src={`${moduleUrl(module)}/actions/workflows/verify.yaml/badge.svg`} />
+      <img src={imgUrl} />
     )
   }
 

--- a/src/components/module/Module.tsx
+++ b/src/components/module/Module.tsx
@@ -5,7 +5,15 @@ import {connect} from 'react-redux';
 import './Module.scss'
 import {RootState} from '../../app/store';
 import {Mode, selectMode} from '../../features/mode/modeSlice';
-import {moduleDisplayName, moduleLatestVersion, ModuleModel, moduleStatus, moduleType, moduleUrl} from '../../models';
+import {
+  moduleBuildBadgeUrl,
+  moduleDisplayName,
+  moduleLatestVersion,
+  ModuleModel,
+  moduleStatus,
+  moduleType,
+  moduleUrl
+} from '../../models';
 import {ModuleLink} from '../module-link';
 
 interface ModuleValues {
@@ -74,8 +82,10 @@ class ModuleInternal extends React.Component<ModuleProps, any> {
   }
 
   get moduleBuildBadge() {
+    const imgUrl = moduleBuildBadgeUrl(this.props.module)
+
     return (
-      <img src={`${moduleUrl(this.props.module)}/actions/workflows/verify.yaml/badge.svg`} />
+      <img src={imgUrl} />
     )
   }
 }

--- a/src/features/catalog/catalogSlice.ts
+++ b/src/features/catalog/catalogSlice.ts
@@ -15,7 +15,9 @@ export interface CatalogState {
 
 const initialState: CatalogState = {
   value: undefined,
-  filters: {},
+  filters: {
+    status: 'released'
+  },
   status: Status.idle
 }
 

--- a/src/models/module.model.ts
+++ b/src/models/module.model.ts
@@ -34,6 +34,16 @@ export const moduleStatus = (module: ModuleModel): string => {
   return 'released'
 }
 
+export const moduleBuildBadgeUrl = (module: ModuleModel) => {
+  const status: string = moduleStatus(module)
+
+  if (status === 'pending') {
+    return 'https://img.shields.io/badge/Verify-in%20progress-lightgrey'
+  }
+
+  return `${moduleUrl(module)}/actions/workflows/verify.yaml/badge.svg`
+}
+
 export const moduleDisplayName = (module: ModuleModel): string => {
   return module.displayName || module.name
 }


### PR DESCRIPTION
- Fixes default status filter to show only "Released" modules when the catalog initially loads - closes #241
- Changes badge displayed for pending modules to `Verify: in progress` - closes #240

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>