### PR TITLE
Add a new category called "examples" to the catalog.

### DIFF
--- a/catalog.yaml
+++ b/catalog.yaml
@@ -154,7 +154,22 @@ aliases:
   - id: github.com/terraform-ibm-modules/terraform-ibm-toolkit-cloud-operator
     aliases:
       - github.com/cloud-native-toolkit/terraform-ibm-cloud-operator
+  - id: github.com/terraform-ibm-modules/terraform-gitops-ubi
+    aliases:
+      - github.com/cloud-native-toolkit/terraform-gitops-ubi
 categories:
+  - category: examples
+    categoryName: Examples
+    selection: multiple
+    modules:
+     -  cloudProvider: ""
+        softwareProvider: ""
+        type: gitops
+        id: github.com/terraform-ibm-modules/terraform-gitops-ubi
+        group: ""
+        displayName: terraform-gitops-ubi
+        name: terraform-gitops-ubi
+        description: "That module will add a new 'Argo CD config' to deploy an 'ubi' container to a Cluster"
   - category: cluster
     categoryName: Cluster
     selection: single


### PR DESCRIPTION
@seansund @balasgit @nheidloff @Vishal-Ramani @dptiwari-ibm 

We need a new category called "examples" in the catalog for our example module.

These are the related to tasks:
* Epic created: https://github.com/cloud-native-toolkit/software-everywhere/issues/511
* Module request created: https://github.com/cloud-native-toolkit/software-everywhere/issues/512

That is the related repository:
* https://github.com/cloud-native-toolkit/terraform-gitops-ubi